### PR TITLE
Update check to specify which server to connect to. 

### DIFF
--- a/bin/check-ssl-cert.rb
+++ b/bin/check-ssl-cert.rb
@@ -64,7 +64,7 @@ class CheckSSLCert < Sensu::Plugin::Check::CLI
          long: '--port PORT'
 
   def ssl_cert_expiry
-    `openssl s_client -connect #{config[:host]}:#{config[:port]} < /dev/null 2>&1 | openssl x509 -enddate -noout`.split('=').last
+    `openssl s_client -servername #{config[:host]} -connect #{config[:host]}:#{config[:port]} < /dev/null 2>&1 | openssl x509 -enddate -noout`.split('=').last
   end
 
   def ssl_pem_expiry

--- a/bin/check-ssl-host.rb
+++ b/bin/check-ssl-host.rb
@@ -109,7 +109,7 @@ class CheckSSLHost < Sensu::Plugin::Check::CLI
     # CA.
     valid = true
     parent = nil
-    certs.reverse.each do |c|
+    certs.reverse_each do |c|
       if parent
         valid &= c.verify(parent.public_key)
       end

--- a/lib/sensu-plugins-ssl/version.rb
+++ b/lib/sensu-plugins-ssl/version.rb
@@ -6,7 +6,7 @@ module SensuPluginsSSL
   module Version
     MAJOR = 0
     MINOR = 0
-    PATCH = 1
+    PATCH = 2
 
     VER_STRING = [MAJOR, MINOR, PATCH, 'alpha.2'].compact.join('.')
 


### PR DESCRIPTION
This is useful to check SSL certificates to server connecting using SNI,
such as CloudFront.

More information about SNI can be found here:
- http://serverfault.com/questions/594368/openssl-returns-different-ssl-certificate-to-that-shown-by-chrome
- http://en.wikipedia.org/wiki/Server_Name_Indication
