### PR TITLE
Add GitHub diff links à la keepachangelog.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,8 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## 0.0.1 - 2015-05-21
 ### Added
 - initial release
+
+[unreleased]: https://github.com/sensu-plugins/sensu-plugins-ssl/compare/0.0.4...HEAD
+[0.0.4]: https://github.com/sensu-plugins/sensu-plugins-ssl/compare/0.0.3...0.0.4
+[0.0.3]: https://github.com/sensu-plugins/sensu-plugins-ssl/compare/0.0.2...0.0.3
+[0.0.2]: https://github.com/sensu-plugins/sensu-plugins-ssl/compare/0.0.1...0.0.2


### PR DESCRIPTION
It took me a while to figure out what was "magic" about the version number links in [keepachangelog.com's sample change log](http://keepachangelog.com/CHANGELOG.md).  No magic, just "reference-style" Markdown links pointing to GitHub URLs.
