### PR TITLE
Added --address commandline parameter to check-ssl-host.rb, to allow …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+### Added
+- check-ssl-host.rb: Added optional `address` command line parameter for specifying the address of the server to
+                     connect to, to override the `hostname` parameter (which is still used for verification/SNI)
+
 ## [1.0.0]
 ### Changed
 - Updated Rubocop to 0.40, applied auto-correct


### PR DESCRIPTION
## Pull Request Checklist
#### General
- [X] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [X] Update README with any necessary configuration snippets
- [X] Binstubs are created if needed
- [X] RuboCop passes
- [X] Existing tests pass 
#### Purpose

 Added --address command line parameter to check-ssl-host.rb, to allow using a server address that is different from the hostname, possibly an IP address.
#### Known Compatablity Issues
