### PR TITLE
Better error handling from RestClient / Qualys API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 - check-ssl-host.rb: Basic IMAP STARTTLS negotiation
 
-- check-ssl-qualys.rb: Handle API errors with status unknow instead of unhandled "Check failed to run".
+- check-ssl-qualys.rb: Handle API errors with status unknown instead of unhandled "Check failed to run".
 
 ## [1.0.0]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 - check-ssl-host.rb: Basic IMAP STARTTLS negotiation
 
+- check-ssl-qualys.rb: Handle API errors with status unknow instead of unhandled "Check failed to run".
+
 ## [1.0.0]
 ### Changed
 - Updated Rubocop to 0.40, applied auto-correct

--- a/bin/check-ssl-qualys.rb
+++ b/bin/check-ssl-qualys.rb
@@ -90,8 +90,12 @@ class CheckSSLQualys < Sensu::Plugin::Check::CLI
   def ssl_api_request(from_cache)
     params = { host: config[:domain] }
     params[:startNew] = 'on' unless from_cache
-    r = RestClient.get("#{config[:api_url]}analyze", params: params)
-    warning "HTTP#{r.code} recieved from API" unless r.code == 200
+    begin
+      r = RestClient.get("#{config[:api_url]}analyze", params: params)
+      warning "HTTP#{r.code} recieved from API" unless r.code == 200
+    rescue RestClient::ExceptionWithResponse => e
+      unknown e.response
+    end
     JSON.parse(r.body)
   end
 


### PR DESCRIPTION
## Pull Request Checklist

There is bug with `Check failed to run: 429 Too Many Requests, [stacktrace]`. It is caused because RestClient raises exception for code other than [200, 207, 301, 302, 303, 307](https://github.com/rest-client/rest-client#exceptions-see-httpwwww3orgprotocolsrfc2616rfc2616-sec10html)

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### Purpose

Raise uknown error instead of "Check failed to run" with stack trace.

#### Known Compatablity Issues

None. There is no need for any changes in configuration.
