### PR TITLE
Handle case when domain is not rated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 - check-ssl-qualys.rb: Handle API errors with status unknow instead of unhandled "Check failed to run".
 
+- check-ssl-qualys.rb: Handle nil grade_rank as critical not rated
+
 ## [1.0.0]
 ### Changed
 - Updated Rubocop to 0.40, applied auto-correct

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 - check-ssl-host.rb: Basic IMAP STARTTLS negotiation
 
+- check-ssl-qualys.rb: Handle API errors with status unknow instead of unhandled "Check failed to run".
+
 ## [1.0.0]
 ### Changed
 - Updated Rubocop to 0.40, applied auto-correct

--- a/bin/check-ssl-qualys.rb
+++ b/bin/check-ssl-qualys.rb
@@ -126,7 +126,7 @@ class CheckSSLQualys < Sensu::Plugin::Check::CLI
 
   def run
     grade = lowest_grade
-    if !grade
+    unless grade
       message "#{config[:domain]} not rated"
       critical
     end

--- a/bin/check-ssl-qualys.rb
+++ b/bin/check-ssl-qualys.rb
@@ -126,6 +126,10 @@ class CheckSSLQualys < Sensu::Plugin::Check::CLI
 
   def run
     grade = lowest_grade
+    if !grade
+      message "#{config[:domain]} not rated"
+      critical
+    end
     message "#{config[:domain]} rated #{grade}"
     grade_rank = GRADE_OPTIONS.index(grade)
     if grade_rank > config[:critical]

--- a/bin/check-ssl-qualys.rb
+++ b/bin/check-ssl-qualys.rb
@@ -90,8 +90,12 @@ class CheckSSLQualys < Sensu::Plugin::Check::CLI
   def ssl_api_request(from_cache)
     params = { host: config[:domain] }
     params[:startNew] = 'on' unless from_cache
-    r = RestClient.get("#{config[:api_url]}analyze", params: params)
-    warning "HTTP#{r.code} recieved from API" unless r.code == 200
+    begin
+      r = RestClient.get("#{config[:api_url]}analyze", params: params)
+      warning "HTTP#{r.code} recieved from API" unless r.code == 200
+    rescue RestClient::ExceptionWithResponse => e
+      unknown e.response
+    end
     JSON.parse(r.body)
   end
 


### PR DESCRIPTION
## Pull Request Checklist

When https is not accessible from internet / qualys api it causes to give empty grade and then empty grade_rank variable. This gives an error: "Check failed to run: undefined method `>' for nil:NilClass"

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### Purpose

Handle as critical when check didn't give any grade with comment "domain not rated" which is better than "undefined method > for nil".

#### Known Compatablity Issues

None.