### PR TITLE
Loosen dependency on sensu-plugin from `~> 1.2` to `>= 1.2, < 3.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+- Loosen dependency on sensu-plugin from `~> 1.2` to `>= 1.2, < 3.0`
+
 ## [1.2.0] - 2017-05-17
 ### Changed
 - check-ssl-qualys.rb: removed dependency on rest-client so we don't need a c compiler (@baweaver)

--- a/sensu-plugins-ssl.gemspec
+++ b/sensu-plugins-ssl.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsSSL::Version::VER_STRING
 
-  s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
+  s.add_runtime_dependency 'sensu-plugin', '>= 1.2', '< 3.0'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

~Update README with any necessary configuration snippets~

~Binstubs are created if needed~

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

The 2.0 of sensu-plugin was recently released.

#### Known Compatablity Issues

The few [backwards-incompatible changes](https://github.com/sensu-plugins/sensu-plugin/blob/master/CHANGELOG.md#v200---2017-03-29) shouldn't impact this plugin at all.