### PR TITLE
Removed dependencies requiring compilation

### DIFF
--- a/bin/check-ssl-qualys.rb
+++ b/bin/check-ssl-qualys.rb
@@ -40,7 +40,6 @@
 #
 
 require 'sensu-plugin/check/cli'
-require 'rest-client'
 require 'json'
 
 # Checks a single DNS entry has a rating above a certain level
@@ -90,13 +89,14 @@ class CheckSSLQualys < Sensu::Plugin::Check::CLI
   def ssl_api_request(from_cache)
     params = { host: config[:domain] }
     params[:startNew] = 'on' unless from_cache
-    begin
-      r = RestClient.get("#{config[:api_url]}analyze", params: params)
-      warning "HTTP#{r.code} recieved from API" unless r.code == 200
-    rescue RestClient::ExceptionWithResponse => e
-      unknown e.response
-    end
-    JSON.parse(r.body)
+
+    uri       = URI("#{config[:api_url]}analyze")
+    uri.query = URI.encode_www_form(params)
+    response  = Net::HTTP.get_response(uri)
+
+    warning "Bad response recieved from API" unless response.is_a?(Net::HTTPSuccess)
+
+    JSON.parse(response.body)
   end
 
   def ssl_check(from_cache)

--- a/bin/check-ssl-qualys.rb
+++ b/bin/check-ssl-qualys.rb
@@ -94,7 +94,7 @@ class CheckSSLQualys < Sensu::Plugin::Check::CLI
     uri.query = URI.encode_www_form(params)
     response  = Net::HTTP.get_response(uri)
 
-    warning "Bad response recieved from API" unless response.is_a?(Net::HTTPSuccess)
+    warning 'Bad response recieved from API' unless response.is_a?(Net::HTTPSuccess)
 
     JSON.parse(response.body)
   end

--- a/sensu-plugins-ssl.gemspec
+++ b/sensu-plugins-ssl.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |s|
   s.version                = SensuPluginsSSL::Version::VER_STRING
 
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
-  s.add_runtime_dependency 'rest-client',  '1.8.0'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'


### PR DESCRIPTION
Currently this plugin has a dependency on rest-client which requires the building of C extensions. The built-in Ruby `Net::HTTP` methods achieve the same results without this extra requirement, both speeding installation of this gem and allowing it to be freely installed on systems disabling C compilers for security reasons.
