### PR TITLE
Use shell escaped strings for keystore call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- `check-java-keystore-cert.rb`: Escape variables sent to shell on calls to keytool. (@rs-mrichmond)
+
 ## [1.2.0] - 2017-05-17
 ### Changed
 - check-ssl-qualys.rb: removed dependency on rest-client so we don't need a c compiler (@baweaver)

--- a/bin/check-java-keystore-cert.rb
+++ b/bin/check-java-keystore-cert.rb
@@ -22,6 +22,7 @@
 #
 
 require 'date'
+require 'shellwords'
 require 'sensu-plugin/check/cli'
 
 class CheckJavaKeystoreCert < Sensu::Plugin::Check::CLI
@@ -53,9 +54,9 @@ class CheckJavaKeystoreCert < Sensu::Plugin::Check::CLI
          required: true
 
   def certificate_expiration_date
-    result = `keytool -keystore #{config[:path]} \
-                      -export -alias #{config[:alias]} \
-                      -storepass #{config[:password]} 2>&1 | \
+    result = `keytool -keystore #{Shellwords.escape(config[:path])} \
+                      -export -alias #{Shellwords.escape(config[:alias])} \
+                      -storepass #{Shellwords.escape(config[:password])} 2>&1 | \
               openssl x509 -enddate -inform der -noout 2>&1`
 
     # rubocop:disable Style/SpecialGlobalVars


### PR DESCRIPTION
Why:
  * In many instances keystore paths or passwords may contain special characters that cause issues in shell commands

How:
  * Use the ruby shellwords library in the ruby stdlib to escape the strings before sending to the shell exec.

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatablity Issues

