### PR TITLE
Add missing net/http require

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- `check-ssl-qualys.rb`: Fix missing `net/http` require that prevented the check from executing (@eheydrick)
+
 ## [1.3.0] 2017-05-18
 ### Changed
 - `check-java-keystore-cert.rb`: Escape variables sent to shell on calls to keytool. (@rs-mrichmond)

--- a/bin/check-ssl-qualys.rb
+++ b/bin/check-ssl-qualys.rb
@@ -18,7 +18,6 @@
 #
 # DEPENDENCIES:
 #   gem: sensu-plugin
-#   gem: rest-client
 #
 # USAGE:
 #   # Basic usage
@@ -41,6 +40,7 @@
 
 require 'sensu-plugin/check/cli'
 require 'json'
+require 'net/http'
 
 # Checks a single DNS entry has a rating above a certain level
 class CheckSSLQualys < Sensu::Plugin::Check::CLI


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

Fixes #27

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Existing tests pass 

#### Purpose

Fix bug in qualys check

Before:

> $ /opt/sensu/embedded/bin/ruby check-ssl-qualys.rb -d github.com
Check failed to run: undefined method `URI' for #<CheckSSLQualys:0x00000001fff608>, ["check-ssl-qualys.rb:94:in `ssl_api_request'", "check-ssl-qualys.rb:104:in `ssl_check'", "check-ssl-qualys.rb:111:in `block in ssl_recheck'", "check-ssl-qualys.rb:110:in `upto'", "check-ssl-qualys.rb:110:in `ssl_recheck'", "check-ssl-qualys.rb:119:in `ssl_grades'", "check-ssl-qualys.rb:125:in `lowest_grade'", "check-ssl-qualys.rb:129:in `run'", "/opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-plugin-1.4.2/lib/sensu-plugin/cli.rb:58:in `block in <class:CLI>'"]

After:

> $ /opt/sensu/embedded/bin/ruby check-ssl-qualys.rb -d github.com
CheckSSLQualys OK: github.com rated A+

#### Known Compatablity Issues
 
None
