### PR TITLE
Add ssl root anchor script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- `check-ssl-anchor.rb`: Add check for a specific root certificate signature. (@pgporada)
+- `check-ssl-anchor_spec.rb`: Tests for the `check-ssl-anchor.rb` script (@pgporada)
+
 ## [1.3.1] - 2017-05-30
 ### Fixed
 - `check-ssl-qualys.rb`: Fix missing `net/http` require that prevented the check from executing (@eheydrick)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 Check that a specific website is chained to a specific root certificate (Let's Encrypt for instance).
 
 ```
-./check-ssl-anchor.rb -u example.com -a "i:/O=Digital Signature Trust Co./CN=DST Root CA X3"
+./bin/check-ssl-anchor.rb -u example.com -a "i:/O=Digital Signature Trust Co./CN=DST Root CA X3"
 ```
 
 ### `bin/check-ssl-crl.rb`
@@ -49,3 +49,5 @@ Critical and Warning thresholds are specified in minutes.
 [Installation and Setup](http://sensu-plugins.io/docs/installation_instructions.html)
 
 ## Notes
+
+`bin/check-ssl-anchor.rb` and `bin/check-ssl-host.rb` would be good to run in combination with each other to test that the chain is anchored to a specific certificate and each certificate in the chain is correctly signed.

--- a/README.md
+++ b/README.md
@@ -10,12 +10,21 @@
 
 ## Files
  * bin/check-java-keystore-cert.rb
+ * bin/check-ssl-anchor.rb
  * bin/check-ssl-crl.rb
  * bin/check-ssl-cert.rb
  * bin/check-ssl-host.rb
  * bin/check-ssl-qualys.rb
 
 ## Usage
+
+### `bin/check-ssl-anchor.rb`
+
+Check that a specific website is chained to a specific root certificate (Let's Encrypt for instance).
+
+```
+./check-ssl-anchor.rb -u example.com -a "i:/O=Digital Signature Trust Co./CN=DST Root CA X3"
+```
 
 ### `bin/check-ssl-crl.rb`
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ Critical and Warning thresholds are specified in minutes.
 
 [Installation and Setup](http://sensu-plugins.io/docs/installation_instructions.html)
 
+## Testing
+
+To run the testing suite, you'll need to have a working `ruby` environment, `gem`, and `bundler` installed. We use `rake` to run the `rspec` tests automatically.
+
+    bundle install
+    bundle update
+    bundle exec rake
+
 ## Notes
 
 `bin/check-ssl-anchor.rb` and `bin/check-ssl-host.rb` would be good to run in combination with each other to test that the chain is anchored to a specific certificate and each certificate in the chain is correctly signed.

--- a/bin/check-ssl-anchor.rb
+++ b/bin/check-ssl-anchor.rb
@@ -1,0 +1,104 @@
+#! /usr/bin/env ruby
+#
+#   check-ssl-anchor
+#
+# DESCRIPTION:
+#   Check that a certificate is chained to a specific root certificate
+#
+# OUTPUT:
+#   plain text
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#
+# USAGE:
+#
+#   Check a specific website is chained to a specific root certificate (Let's Encrypt for instance)
+#       ./check-ssl-anchor.rb \
+#           -u example.com \
+#           -a "i:/O=Digital Signature Trust Co./CN=DST Root CA X3"
+#
+# NOTES:
+#   This is basically a ruby wrapper around the following openssl command.
+#
+#       openssl s_client -connect example.com:443 -servername example.com
+#
+#
+#
+#   Use the -s flag if you need to override SNI (Server Name Indication). If you
+#   are seeing discrepencies between `openssl s_client` and browser, that's a good
+#   indication to use this flag.
+#
+# LICENSE:
+#   Copyright 2017 Phil Porada <philporada@gmail.com>
+#
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugin/check/cli'
+
+#
+# Check certificate is anchored to a specific root
+#
+class CheckSSLAnchor < Sensu::Plugin::Check::CLI
+  option :host,
+         description: 'Host to check',
+         short: '-h',
+         long: '--host HOST',
+         required: true
+
+  option :anchor,
+         description: 'An anchor looks something like /O=Digital Signature Trust Co./CN=DST Root CA X3',
+         short: '-a',
+         long: '--anchor ANCHOR_VAL',
+         required: true
+
+  option :servername,
+         description: 'Set the TLS SNI (Server Name Indication) extension',
+         short: '-s',
+         long: '--servername SERVER'
+
+  option :port,
+         description: 'Port on server to check',
+         short: '-p',
+         long: '--port PORT',
+         default: 443
+
+  def validate_opts
+    config[:servername] = config[:host] unless config[:servername]
+  end
+
+  # Do the actual work and massage some data
+  def anchor_information
+    data = `openssl s_client \
+                -connect #{config[:host]}:#{config[:port]} \
+                -servername #{config[:servername]} < /dev/null 2>&1 | \
+            awk '/Certificate chain/,/---/'`.split(/$/).map(&:strip)
+    data = data.reject(&:empty?)
+    if data[0] == 'Certificate chain'
+      data.slice!(0)
+      data.slice!(-1)
+    else
+      data = 'NOTOK'
+    end
+    data
+  end
+
+  def run
+    validate_opts
+    data = anchor_information
+    if data == 'NOTOK'
+      critical 'An error was encountered while trying to retrieve the certificate chain.'
+    end
+
+    if data[-1] == config[:anchor].to_s
+      ok 'Root anchor has been found.'
+    else
+      critical 'Root anchor did not match. Found "' + data[-1] + '" instead.'
+    end
+  end
+end

--- a/bin/check-ssl-anchor.rb
+++ b/bin/check-ssl-anchor.rb
@@ -16,7 +16,7 @@
 #
 # USAGE:
 #
-#   Check a specific website is chained to a specific root certificate (Let's Encrypt for instance)
+#   Check that a specific website is chained to a specific root certificate (Let's Encrypt for instance)
 #       ./check-ssl-anchor.rb \
 #           -u example.com \
 #           -a "i:/O=Digital Signature Trust Co./CN=DST Root CA X3"

--- a/bin/check-ssl-anchor.rb
+++ b/bin/check-ssl-anchor.rb
@@ -76,13 +76,10 @@ class CheckSSLAnchor < Sensu::Plugin::Check::CLI
   def anchor_information
     data = `openssl s_client \
                 -connect #{config[:host]}:#{config[:port]} \
-                -servername #{config[:servername]} < /dev/null 2>&1 | \
-            awk '/Certificate chain/,/---/'`.split(/$/).map(&:strip)
+                -servername #{config[:servername]} < /dev/null 2>&1`.match(/Certificate chain(.*)---\nServer certificate/m)[1].split(/$/).map(&:strip)
     data = data.reject(&:empty?)
-    if data[0] == 'Certificate chain'
-      data.slice!(0)
-      data.slice!(-1)
-    else
+
+    unless data[0] =~ /0 s:\/CN=.*/m
       data = 'NOTOK'
     end
     data

--- a/test/check-ssl-anchor_spec.rb
+++ b/test/check-ssl-anchor_spec.rb
@@ -1,0 +1,23 @@
+require_relative '../bin/check-ssl-anchor.rb'
+
+describe CheckSSLAnchor do
+  before(:all) do
+    # Ensure the check isn't run when exiting (which is the default)
+    CheckSSLAnchor.class_variable_set(:@@autorun, nil)
+  end
+
+  let(:check) do
+    CheckSSLAnchor.new ['-h', 'philporada.com', '-a', 'i:/O=Digital Signature Trust Co./CN=DST Root CA X3']
+  end
+
+  it 'should pass check if the root anchor matches what the users -a flag' do
+    expect(check).to receive(:ok).and_raise SystemExit
+    expect { check.run }.to raise_error SystemExit
+  end
+
+  it 'should pass check if the root anchor matches what the users -a flag' do
+    check.config[:anchor] = 'testdata'
+    expect(check).to receive(:critical).and_raise SystemExit
+    expect { check.run }.to raise_error SystemExit
+  end
+end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
No it is not.

#### General

- [X] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [X] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [X] RuboCop passes
(on the check and the test)

- [x] Existing tests pass 

#### New Plugins

- [X] Tests

- [X] Add the plugin to the README

- [X] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

I need to verify that a website is using a specific root certificate anchor. This script allows me to do that.

#### Known Compatablity Issues
You need awk installed. This is essentially a wrapper script. Any tips on how to remove that dependency and do it in ruby would be awesome.
