### PR TITLE
switch to ssllabs v3 api endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md).
 
 ## [Unreleased]
+### Fixed
+- `check-ssl-qualys.rb`: switch to ssllabs v3 api endpoint
 
 ## [1.5.0] - 2017-09-26
 ### Added

--- a/bin/check-ssl-qualys.rb
+++ b/bin/check-ssl-qualys.rb
@@ -56,7 +56,7 @@ class CheckSSLQualys < Sensu::Plugin::Check::CLI
   option :api_url,
          description: 'The URL of the API to run against',
          long: '--api-url URL',
-         default: 'https://api.ssllabs.com/api/v2/'
+         default: 'https://api.ssllabs.com/api/v3/'
 
   option :warn,
          short: '-w GRADE',


### PR DESCRIPTION
The v2 endpoint has been dead for the last ~60 days.

## Pull Request Checklist

Resolves #33 

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] RuboCop passes

- [x] Existing tests pass


