### PR TITLE
Addressing multiple issues with timing out with `check-ssl-qualys.rb`:

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,3 +28,6 @@ RegexpLiteral:
 
 Style/Documentation:
   Enabled: false
+
+# AllCops:
+#   TargetRubyVersion: 2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 ### Fixed
 - `check-ssl-hsts-preloadable.rb`: Fixed testing warnings for if a domain can be HSTS preloaded (@rwky)
 
+### Breaking Changes
+- `check-ssl-qualys.rb`: when you submit a request with caching enabled it will return back a response including an eta key. Rather than sleeping for some arbitrary number of time we now use this key when its greater than `--between-checks` to wait before attempting the next attempt to query. If it is lower or not present we fall back to `--between-checks` (@majormoses)
+- `check-ssl-qualys.rb`: new `--timeout` parameter to short circuit slow apis (@majormoses)
+
+### Changed
+- `check-ssl-qualys.rb`: updated `--api-url` to default to `v3` but remains backwards compatible (@jhoblitt) (@majormoses)
+
+### Added
+`check-ssl-qualys.rb`: option `--debug` to enable debug logging (@majormoses)
+
 ## [1.5.0] - 2017-09-26
 ### Added
 - Ruby 2.4.1 testing

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ or an online CRL:
 
 Critical and Warning thresholds are specified in minutes.
 
+### `bin/check-ssl-qualys.rb`
+
+Checks the ssllabs qualysis api for grade of your server, this check can be quite long so it should not be scheduled with a low interval and will probably need to adjust the check `timeout` options per the [check attributes spec](https://docs.sensu.io/sensu-core/1.2/reference/checks/#check-attributes) based on my tests you should expect this to take around 3 minutes.
+```
+./bin/check-ssl-qualys.rb -d google.com
+```
+
+
 ## Installation
 
 [Installation and Setup](http://sensu-plugins.io/docs/installation_instructions.html)

--- a/bin/check-ssl-qualys.rb
+++ b/bin/check-ssl-qualys.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 # encoding: UTF-8
+
 #  check-ssl-qualys.rb
 #
 # DESCRIPTION:
@@ -41,6 +42,7 @@
 require 'sensu-plugin/check/cli'
 require 'json'
 require 'net/http'
+require 'timeout'
 
 # Checks a single DNS entry has a rating above a certain level
 class CheckSSLQualys < Sensu::Plugin::Check::CLI
@@ -56,7 +58,7 @@ class CheckSSLQualys < Sensu::Plugin::Check::CLI
   option :api_url,
          description: 'The URL of the API to run against',
          long: '--api-url URL',
-         default: 'https://api.ssllabs.com/api/v2/'
+         default: 'https://api.ssllabs.com/api/v3/'
 
   option :warn,
          short: '-w GRADE',
@@ -72,6 +74,12 @@ class CheckSSLQualys < Sensu::Plugin::Check::CLI
          proc: proc { |g| GRADE_OPTIONS.index(g) },
          default: 3 # 'B'
 
+  option :debug,
+         long: '--debug BOOL',
+         description: 'toggles extra debug printing',
+         boolean: true,
+         default: false
+
   option :num_checks,
          short: '-n NUM_CHECKS',
          long: '--number-checks NUM_CHECKS',
@@ -82,17 +90,31 @@ class CheckSSLQualys < Sensu::Plugin::Check::CLI
   option :between_checks,
          short: '-t SECONDS',
          long: '--time-between SECONDS',
-         description: 'The time between each poll of the API',
+         description: 'The fallback time between each poll of the API, when an ETA is given by the previous response and is higher than this value it is used',
          proc: proc { |t| t.to_i },
          default: 10
 
+  option :timeout,
+         short: '-t SECONDS',
+         descriptions: 'the ammount of seconds that this is allowed to run for',
+         proc: proc(&:to_i),
+         default: 300
+
   def ssl_api_request(from_cache)
     params = { host: config[:domain] }
-    params[:startNew] = 'on' unless from_cache
+    params[:startNew] = if from_cache == true
+                          'off'
+                        else
+                          'on'
+                        end
 
     uri       = URI("#{config[:api_url]}analyze")
     uri.query = URI.encode_www_form(params)
-    response  = Net::HTTP.get_response(uri)
+    begin
+      response = Net::HTTP.get_response(uri)
+    rescue StandardError => e
+      warning e
+    end
 
     warning 'Bad response recieved from API' unless response.is_a?(Net::HTTPSuccess)
 
@@ -107,11 +129,37 @@ class CheckSSLQualys < Sensu::Plugin::Check::CLI
 
   def ssl_recheck
     1.upto(config[:num_checks]) do |step|
-      json = ssl_check(step != 1)
+      p "step: #{step}" if config[:debug]
+      start_time = Time.now
+      p "start_time: #{start_time}" if config[:debug]
+      json = if step == 1
+               ssl_check(false)
+             else
+               ssl_check(true)
+             end
       return json if json['status'] == 'READY'
-      sleep(config[:between_checks])
+      if json['endpoints'] && json['endpoints'].is_a?(Array)
+        p "endpoints: #{json['endpoints']}" if config[:debug]
+        # The api response sometimes has low eta (which seems unrealistic) from
+        # my tests that can be 0 or low numbers which would imply it is done...
+        # Basically we check if present and if its higher than the specified
+        # time to wait between checks. If so we use the eta from the api get
+        # response otherwise we use the time between check values. We have an
+        # overall timeout that protects us from the api telling us to wait for
+        # insanely long time periods. The highest I have seen the eta go was
+        # around 250 seconds but put it in just in case as the api has very
+        # erratic response times.
+        if json['endpoints'].first.is_a?(Hash) && json['endpoints'].first.key?('eta') && json['endpoints'].first['eta'] > config[:between_checks]
+          p "eta: #{json['endpoints'].first['eta']}" if config[:debug]
+          sleep(json['endpoints'].first['eta'])
+        else
+          p "sleeping with default: #{config[:between_checks]}" if config[:debug]
+          sleep(config[:between_checks])
+        end
+      end
+      p "elapsed: #{Time.now - start_time}" if config[:debug]
+      warning 'Timeout waiting for check to finish' if step == config[:num_checks]
     end
-    warning 'Timeout waiting for check to finish'
   end
 
   def ssl_grades
@@ -121,23 +169,25 @@ class CheckSSLQualys < Sensu::Plugin::Check::CLI
   end
 
   def lowest_grade
-    ssl_grades.sort_by! { |g| GRADE_OPTIONS.index(g) } .reverse![0]
+    ssl_grades.sort_by! { |g| GRADE_OPTIONS.index(g) }.reverse![0]
   end
 
   def run
-    grade = lowest_grade
-    unless grade
-      message "#{config[:domain]} not rated"
-      critical
-    end
-    message "#{config[:domain]} rated #{grade}"
-    grade_rank = GRADE_OPTIONS.index(grade)
-    if grade_rank > config[:critical]
-      critical
-    elsif grade_rank > config[:warn]
-      warning
-    else
-      ok
+    Timeout.timeout(config[:timeout]) do
+      grade = lowest_grade
+      unless grade
+        message "#{config[:domain]} not rated"
+        critical
+      end
+      message "#{config[:domain]} rated #{grade}"
+      grade_rank = GRADE_OPTIONS.index(grade)
+      if grade_rank > config[:critical]
+        critical
+      elsif grade_rank > config[:warn]
+        warning
+      else
+        ok
+      end
     end
   end
 end


### PR DESCRIPTION
- added an overall timeout parameter to short circuit slow api
- when you call the api beyond the initial attempt it needs to wait until the report is done. Previously it would sleep for a specified arbitrary value and would often timeout. Now we look at the api response and if it has an ETA and the ETA is larger than the value of `--between-checks` we use it. We check if its greater than the specified as in many cases this has been found to be unreliable when seeing small numbers but seems legit when the api is slower to complete the report. In some cases we see a 0 eta which one might assume is complete or near complete but often saw several 0's in a row leading me to put in that stipulation on using it.
- adding documentation about how long it takes and that you probably need to configure your sensu check to have a longer timeout or sensu will kill the process.
- moved to v3 of the api (backwards compatible) I saw little to no difference in speed but the docs indicate that v2 is deprecated

testing artifact: https://gist.github.com/majormoses/b549f92fc02894a15a842b29f528da6f

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

Fixes #35, #33 

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass


#### Purpose
Make this check actually work with defaults consistently

#### Known Compatibility Issues
Essentially the check may run longer than in previous versions. There are now multiple nobs to fine tune what you want but it now works every time I have tried it.
Knobs:
- `--timeout`: this is an overall timeout circuit breaker and defaults to 5 minutes
- `--number-checks`: this indicates how many requests will be attempted before giving up, left default at 24
- `--time-between-checks`: previously this was a constant amount of time in between polling for report being done. Now this acts more as a fallback value. The api response includes an `eta` key and value that indicates when the api thinks you should check back. It seemed very temperamental and you still need to have a value to wait between the initial request and polling for completion so we decided to use the same value and treat this as a fallback. In cases where the `eta` is less than this we use this value instead 