### PR TITLE
Feature/anchor regexp 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 ### Added
 - Travis build automation to generate Sensu Asset tarballs that can be used n conjunction with Sensu provided ruby runtime assets and the Bonsai Asset Index
 - Require latest sensu-plugin for [Sensu Go support](https://github.com/sensu-plugins/sensu-plugin#sensu-go-enablement)
+- New option to treat anchor argument as a regexp
+
+### Changed
+- `check-ssl-anchor.rb` uses regexp to test for present of certificates in cert chain that works with both openssl 1.0 and 1.1 formatting
+
+### Fixed
+- ssl-anchor test now uses regexp
 
 ## [2.0.1] - 2018-05-30
 ### Fixed

--- a/bin/check-ssl-anchor.rb
+++ b/bin/check-ssl-anchor.rb
@@ -102,8 +102,8 @@ class CheckSSLAnchor < Sensu::Plugin::Check::CLI
     puts config[:regexp]
     # rubocop:disable Style/IfInsideElse
     if config[:regexp]
-      ra = Regexp.new(config[:anchor].to_s)
-      if data[-1] =~ ra
+      anchor_regexp = Regexp.new(config[:anchor].to_s)
+      if data[-1] =~ anchor_regexp
         ok 'Root anchor has been found.'
       else
         critical 'Root anchor did not match regexp /' + config[:anchor].to_s + "/\nFound \"" + data[-1] + '" instead.'

--- a/sensu-plugins-ssl.gemspec
+++ b/sensu-plugins-ssl.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'sensu-plugin', '~> 4.0'
 
-  s.add_development_dependency 'bundler',                   '~> 1.7'
+  s.add_development_dependency 'bundler',                   '~> 2.1'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
   s.add_development_dependency 'github-markup',             '~> 3.0'
   s.add_development_dependency 'pry',                       '~> 0.10'

--- a/test/check-ssl-anchor_spec.rb
+++ b/test/check-ssl-anchor_spec.rb
@@ -7,7 +7,7 @@ describe CheckSSLAnchor do
   end
 
   let(:check) do
-    CheckSSLAnchor.new ['-h', 'philporada.com', '-a', 'i:/O=Digital Signature Trust Co./CN=DST Root CA X3']
+    CheckSSLAnchor.new ['-h', 'philporada.com', '-a', 'i:\/?O ?= ?Digital Signature Trust Co.,? ?\/?CN ?= ?DST Root CA X3', '-r']
   end
 
   it 'should pass check if the root anchor matches what the users -a flag' do
@@ -17,6 +17,7 @@ describe CheckSSLAnchor do
 
   it 'should pass check if the root anchor matches what the users -a flag' do
     check.config[:anchor] = 'testdata'
+    check.config[:regexp] = false
     expect(check).to receive(:critical).and_raise SystemExit
     expect { check.run }.to raise_error SystemExit
   end

--- a/test/check-ssl-hsts-preloadable_spec.rb
+++ b/test/check-ssl-hsts-preloadable_spec.rb
@@ -19,11 +19,11 @@ describe CheckSSLHSTSPreloadable do
     expect { check.run }.to raise_error SystemExit
   end
 
-  it 'should pass check if the domain is preloadedable but has warnings' do
-    check.config[:domain] = 'oskuro.net'
-    expect(check).to receive(:warning).and_raise SystemExit
-    expect { check.run }.to raise_error SystemExit
-  end
+  #  it 'should pass check if the domain is preloadedable but has warnings' do
+  #    check.config[:domain] = 'oskuro.net'
+  #    expect(check).to receive(:warning).and_raise SystemExit
+  #    expect { check.run }.to raise_error SystemExit
+  #  end
 
   it 'should pass check if not preloadedable' do
     check.config[:domain] = 'example.com'

--- a/test/check-ssl-hsts-preloadable_spec.rb
+++ b/test/check-ssl-hsts-preloadable_spec.rb
@@ -18,13 +18,13 @@ describe CheckSSLHSTSPreloadable do
     expect(check).to receive(:ok).and_raise SystemExit
     expect { check.run }.to raise_error SystemExit
   end
-  
+
   ##
   # Disabled 2020/06/24 JDS
   # Reason:  the hsts-preloadable check depends on a domain lookup from https://hstspreload.org/
   #          There's no way to assure that an indexed domain at hstspreload.org will have a warning
-  #          The previously tested domain 'oskuro.net' no longer issues a warning 
-  #          as its now incompliance with the hsts preload requirements. 
+  #          The previously tested domain 'oskuro.net' no longer issues a warning
+  #          as its now incompliance with the hsts preload requirements.
   ##
   #  it 'should pass check if the domain is preloadedable but has warnings' do
   #    check.config[:domain] = 'oskuro.net'

--- a/test/check-ssl-hsts-preloadable_spec.rb
+++ b/test/check-ssl-hsts-preloadable_spec.rb
@@ -18,7 +18,14 @@ describe CheckSSLHSTSPreloadable do
     expect(check).to receive(:ok).and_raise SystemExit
     expect { check.run }.to raise_error SystemExit
   end
-
+  
+  ##
+  # Disabled 2020/06/24 JDS
+  # Reason:  the hsts-preloadable check depends on a domain lookup from https://hstspreload.org/
+  #          There's no way to assure that an indexed domain at hstspreload.org will have a warning
+  #          The previously tested domain 'oskuro.net' no longer issues a warning 
+  #          as its now incompliance with the hsts preload requirements. 
+  ##
   #  it 'should pass check if the domain is preloadedable but has warnings' do
   #    check.config[:domain] = 'oskuro.net'
   #    expect(check).to receive(:warning).and_raise SystemExit


### PR DESCRIPTION
## Pull Request Checklist

Pull request to address failing errors found in the effort in #67
 
#### General
Two failing tests
1. openssl client connection certificate chain formatting has changed betwen openssl 1.0 and openssl 1.1 
This causes the anchor test to fail and on examination would cause all anchor checks to fail on hosts using openssel 1.1

2.  the check-ssl-hsts-preloadable.rb warning test no longer works because the online lookup at hstspreload.org has no reliable warning example.

##### Fix includes.
* updating plugin logic to use a matching regexp that can handle both openssl 1.0 and 1.1 formatting
* add new option to treat anchor argument as a regexp,
* update spec test to use regexp argument
* disable preload warning test, as the domain used in the test no longer

##### Misc other changes:
* update gemspec deps to make travis happy
  
the check-ssl-anchor.rb  command 

- [X] RuboCop passes

- [X] Existing tests pass

