### PR TITLE
Support for StartTLS

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,8 @@
-
 MethodLength:
   Max: 200
+
+Metrics/BlockLength:
+  Max: 50
 
 LineLength:
   Max: 172
@@ -29,5 +31,11 @@ RegexpLiteral:
 Style/Documentation:
   Enabled: false
 
-# AllCops:
-#   TargetRubyVersion: 2.0
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/NumericPredicate:
+  Enabled: false
+
+AllCops:
+  TargetRubyVersion: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ before_install:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
 install:
 - bundle install
+- bundle update
 rvm:
 - 2.5.8
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
 install:
 - bundle install
 rvm:
-- 2.4.1
+- 2.5.8
 notifications:
   email:
     recipients:
@@ -29,7 +29,7 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 2.4.1
+    rvm: 2.5.8
     repo: sensu-plugins/sensu-plugins-ssl
 - provider: script
   script: bonsai/ruby-runtime/travis-build-bonsai-assets.sh sensu-plugins-ssl
@@ -37,4 +37,4 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 2.4.1
+    rvm: 2.5.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ before_install:
 install:
 - bundle install
 - bundle update
-rvm:
-- 2.5.8
+rvm: 2.7.1
 notifications:
   email:
     recipients:
@@ -28,7 +27,7 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 2.5.8
+    rvm: 2.7.1
     repo: sensu-plugins/sensu-plugins-ssl
 - provider: script
   script: bonsai/ruby-runtime/travis-build-bonsai-assets.sh sensu-plugins-ssl
@@ -36,4 +35,4 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 2.5.8
+    rvm: 2.7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: true
 service: docker
 language: ruby
-cache:
-- bundler
 before_install:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
 install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 - Remove ruby-2.3.0. Upgrade bundler. Fix failing tests (@phumpal).
+- `check-ssl-cert.rb`: Support for StartTLS `--starttls PROTOCOL` (@Elfranne)
 
 ### Breaking Changes
 - Bump `sensu-plugin` dependency from `~> 1.2` to `~> 4.0` you can read the changelog entries for [4.0](https://github.com/sensu-plugins/sensu-plugin/blob/master/CHANGELOG.md#400---2018-02-17), [3.0](https://github.com/sensu-plugins/sensu-plugin/blob/master/CHANGELOG.md#300---2018-12-04), and [2.0](https://github.com/sensu-plugins/sensu-plugin/blob/master/CHANGELOG.md#v200---2017-03-29)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 - Remove ruby-2.3.0. Upgrade bundler. Fix failing tests (@phumpal).
-- `check-ssl-cert.rb`: Support for StartTLS `--starttls PROTOCOL` (@Elfranne)
+- `check-ssl-cert.rb`: Support for StartTLS `--starttls PROTOCOL` (@elfranne)
+- Upgrade to ruby 2.7 and Rubocop 0.86 and fix failing tests (@elfranne).
 
 ### Breaking Changes
 - Bump `sensu-plugin` dependency from `~> 1.2` to `~> 4.0` you can read the changelog entries for [4.0](https://github.com/sensu-plugins/sensu-plugin/blob/master/CHANGELOG.md#400---2018-02-17), [3.0](https://github.com/sensu-plugins/sensu-plugin/blob/master/CHANGELOG.md#300---2018-12-04), and [2.0](https://github.com/sensu-plugins/sensu-plugin/blob/master/CHANGELOG.md#v200---2017-03-29)

--- a/Rakefile
+++ b/Rakefile
@@ -8,12 +8,12 @@ require 'yard/rake/yardoc_task'
 
 ENV['TZ'] = 'CET'
 
-args = [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
+args = %i[spec make_bin_executable yard rubocop check_binstubs]
 
 YARD::Rake::YardocTask.new do |t|
-  OTHER_PATHS = %w().freeze
+  OTHER_PATHS = %w[].freeze
   t.files = ['lib/**/*.rb', 'bin/**/*.rb', OTHER_PATHS]
-  t.options = %w(--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md)
+  t.options = %w[--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md]
 end
 
 RuboCop::RakeTask.new
@@ -31,7 +31,7 @@ desc 'Test for binstubs'
 task :check_binstubs do
   bin_list = Gem::Specification.load('sensu-plugins-ssl.gemspec').executables
   bin_list.each do |b|
-    `which #{ b }`
+    `which #{b}`
     unless $CHILD_STATUS.success?
       puts "#{b} was not a binstub"
       exit

--- a/bin/check-ssl-cert.rb
+++ b/bin/check-ssl-cert.rb
@@ -115,7 +115,7 @@ class CheckSSLCert < Sensu::Plugin::Check::CLI
     config[:servername] = config[:host] unless config[:servername]
 
     @starttls_supported_protocols = %w[smtp pop3 imap ftp xmpp xmpp-server irc postgres mysql lmtp nntp sieve ldap]
-    unless @starttls_supported_protocols.include?(config[:starttls])
+    unless @starttls_supported_protocols.include?(config[:starttls]) # rubocop: disable Style/GuardClause
       unknown "Unsupported StartTLS protocol #{config[:starttls]}" if config[:starttls]
     end
   end

--- a/bin/check-ssl-cert.rb
+++ b/bin/check-ssl-cert.rb
@@ -77,7 +77,7 @@ class CheckSSLCert < Sensu::Plugin::Check::CLI
          description: 'Pass phrase for the private key in PKCS#12 certificate',
          short: '-S',
          long: '--pass '
-         
+
   option :starttls,
          description: 'Use StartTLS. OpenSSL 1.1.1 supports "smtp", "pop3", "imap", "ftp", "xmpp", "xmpp-server", "irc", "postgres", "mysql", "lmtp", "nntp", "sieve" and "ldap".',
          long: '--starttls PROTOCOL '
@@ -89,7 +89,7 @@ class CheckSSLCert < Sensu::Plugin::Check::CLI
   def ssl_cert_starttls
     `openssl s_client -servername #{config[:servername]} -connect #{config[:host]}:#{config[:port]} -starttls #{config[:starttls]} < /dev/null 2>&1 | openssl x509 -enddate -noout`.split('=').last
   end
-  
+
   def ssl_pem_expiry
     OpenSSL::X509::Certificate.new(File.read config[:pem]).not_after # rubocop:disable Style/NestedParenthesizedCalls
   end
@@ -111,9 +111,10 @@ class CheckSSLCert < Sensu::Plugin::Check::CLI
       end
     end
     config[:servername] = config[:host] unless config[:servername]
+
     if config[:starttls]
-      $starttls_supported_protocols =
-      [ 'smtp',
+      @starttls_supported_protocols = [
+        'smtp',
         'pop3',
         'imap',
         'ftp',
@@ -125,8 +126,9 @@ class CheckSSLCert < Sensu::Plugin::Check::CLI
         'lmtp',
         'nntp',
         'sieve',
-        'ldap']
-      unless $starttls_supported_protocols.include? config[:starttls]
+        'ldap'
+      ]
+      unless @starttls_supported_protocols.include? config[:starttls]
         unknown "Unsupported StartTLS protocol #{config[:starttls]}"
       end
     end
@@ -140,7 +142,7 @@ class CheckSSLCert < Sensu::Plugin::Check::CLI
                ssl_pkcs12_expiry
              elsif config[:starttls]
                ssl_cert_starttls
-             else 
+             else
                ssl_cert_expiry
              end
 

--- a/bin/check-ssl-cert.rb
+++ b/bin/check-ssl-cert.rb
@@ -79,15 +79,17 @@ class CheckSSLCert < Sensu::Plugin::Check::CLI
          long: '--pass '
 
   option :starttls,
-         description: 'Use StartTLS. OpenSSL 1.1.1 supports "smtp", "pop3", "imap", "ftp", "xmpp", "xmpp-server", "irc", "postgres", "mysql", "lmtp", "nntp", "sieve" and "ldap".',
+         description: 'Use StartTLS. OpenSSL 1.1.1 supports smtp, pop3, imap, ftp, xmpp, xmpp-server, irc, postgres, mysql, lmtp, nntp, sieve and ldap.',
          long: '--starttls PROTOCOL '
 
   def ssl_cert_expiry
-    `openssl s_client -servername #{config[:servername]} -connect #{config[:host]}:#{config[:port]} < /dev/null 2>&1 | openssl x509 -enddate -noout`.split('=').last
+    `openssl s_client -servername #{config[:servername]} -connect #{config[:host]}:#{config[:port]} \
+    < /dev/null 2>&1 | openssl x509 -enddate -noout`.split('=').last
   end
 
   def ssl_cert_starttls
-    `openssl s_client -servername #{config[:servername]} -connect #{config[:host]}:#{config[:port]} -starttls #{config[:starttls]} < /dev/null 2>&1 | openssl x509 -enddate -noout`.split('=').last
+    `openssl s_client -servername #{config[:servername]} -connect #{config[:host]}:#{config[:port]} -starttls #{config[:starttls]} \
+    < /dev/null 2>&1 | openssl x509 -enddate -noout`.split('=').last
   end
 
   def ssl_pem_expiry
@@ -113,21 +115,7 @@ class CheckSSLCert < Sensu::Plugin::Check::CLI
     config[:servername] = config[:host] unless config[:servername]
 
     if config[:starttls]
-      @starttls_supported_protocols = [
-        'smtp',
-        'pop3',
-        'imap',
-        'ftp',
-        'xmpp',
-        'xmpp-server',
-        'irc',
-        'postgres',
-        'mysql',
-        'lmtp',
-        'nntp',
-        'sieve',
-        'ldap'
-      ]
+      @starttls_supported_protocols = %w[smtp pop3 imap ftp xmpp xmpp-server irc postgres mysql lmtp nntp sieve ldap]
       unless @starttls_supported_protocols.include? config[:starttls]
         unknown "Unsupported StartTLS protocol #{config[:starttls]}"
       end

--- a/bin/check-ssl-cert.rb
+++ b/bin/check-ssl-cert.rb
@@ -114,11 +114,9 @@ class CheckSSLCert < Sensu::Plugin::Check::CLI
     end
     config[:servername] = config[:host] unless config[:servername]
 
-    if config[:starttls]
-      @starttls_supported_protocols = %w[smtp pop3 imap ftp xmpp xmpp-server irc postgres mysql lmtp nntp sieve ldap]
-      unless @starttls_supported_protocols.include? config[:starttls]
-        unknown "Unsupported StartTLS protocol #{config[:starttls]}"
-      end
+    @starttls_supported_protocols = %w[smtp pop3 imap ftp xmpp xmpp-server irc postgres mysql lmtp nntp sieve ldap]
+    unless @starttls_supported_protocols.include?(config[:starttls])
+      unknown "Unsupported StartTLS protocol #{config[:starttls]}" if config[:starttls]
     end
   end
 

--- a/bin/check-ssl-crl.rb
+++ b/bin/check-ssl-crl.rb
@@ -65,7 +65,7 @@ class CheckSSLCRL < Sensu::Plugin::Check::CLI
   def run
     validate_opts
 
-    next_update = OpenSSL::X509::CRL.new(open(config[:url]).read).next_update
+    next_update = OpenSSL::X509::CRL.new(open(config[:url]).read).next_update # rubocop:disable Security/Open
     minutes_until = seconds_to_minutes(Time.parse(next_update.to_s) - Time.now)
 
     critical "#{config[:url]} - Expired #{minutes_until.abs} minutes ago" if minutes_until < 0

--- a/bin/check-ssl-host.rb
+++ b/bin/check-ssl-host.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-# encoding: UTF-8
+
 #  check-ssl-host.rb
 #
 # DESCRIPTION:
@@ -42,7 +42,7 @@ require 'socket'
 # Check SSL Host
 #
 class CheckSSLHost < Sensu::Plugin::Check::CLI
-  STARTTLS_PROTOS = %w(smtp imap).freeze
+  STARTTLS_PROTOS = %w[smtp imap].freeze
 
   check_name 'check_ssl_host'
 
@@ -104,7 +104,7 @@ class CheckSSLHost < Sensu::Plugin::Check::CLI
          long: '--starttls PROTO'
 
   def get_cert_chain(host, port, address, client_cert, client_key)
-    tcp_client = TCPSocket.new(address ? address : host, port)
+    tcp_client = TCPSocket.new(address || host, port)
     handle_starttls(config[:starttls], tcp_client) if config[:starttls]
     ssl_context = OpenSSL::SSL::SSLContext.new
     ssl_context.cert = OpenSSL::X509::Certificate.new File.read(client_cert) if client_cert
@@ -139,6 +139,7 @@ class CheckSSLHost < Sensu::Plugin::Check::CLI
 
     status = socket.readline
     return if /^220 / =~ status
+
     critical "#{config[:host]} - did not receive SMTP 220 in response to STARTTLS"
   end
 
@@ -151,6 +152,7 @@ class CheckSSLHost < Sensu::Plugin::Check::CLI
 
     status = socket.readline
     return if /^a001 OK Begin TLS negotiation now/ =~ status
+
     critical "#{config[:host]} - did not receive OK Begin TLS negotiation now"
   end
 

--- a/bin/check-ssl-hsts-preloadable.rb
+++ b/bin/check-ssl-hsts-preloadable.rb
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
-# encoding: UTF-8
-#  check-ssl-hsts-preloadable.rb
-#
+
+# check-ssl-hsts-preloadable.rb
 # DESCRIPTION:
 #   Checks a domain against the chromium HSTS API returning errors/warnings if the domain is preloadable
 #
@@ -50,7 +49,7 @@ class CheckSSLHSTSPreloadable < Sensu::Plugin::Check::CLI
     response = Net::HTTP.get_response(uri)
 
     case response
-    when Net::HTTPSuccess then
+    when Net::HTTPSuccess
       response
     when Net::HTTPRedirection then
       location = URI(response['location'])
@@ -65,6 +64,7 @@ class CheckSSLHSTSPreloadable < Sensu::Plugin::Check::CLI
     if response.nil?
       return warning 'Bad response recieved from API'
     end
+
     body = JSON.parse(response.body)
     if !body['errors'].empty?
       critical body['errors'].map { |u| u['summary'] }.join(', ')

--- a/bin/check-ssl-hsts-status.rb
+++ b/bin/check-ssl-hsts-status.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-# encoding: UTF-8
+
 #  check-ssl-hsts-preload.rb
 #
 # DESCRIPTION:
@@ -33,7 +33,7 @@ require 'json'
 require 'net/http'
 
 class CheckSSLHSTSStatus < Sensu::Plugin::Check::CLI
-  STATUSES = %w(unknown pending preloaded).freeze
+  STATUSES = %w[unknown pending preloaded].freeze
 
   option :domain,
          description: 'The domain to run the test against',
@@ -68,7 +68,7 @@ class CheckSSLHSTSStatus < Sensu::Plugin::Check::CLI
     response = Net::HTTP.get_response(uri)
 
     case response
-    when Net::HTTPSuccess then
+    when Net::HTTPSuccess
       response
     when Net::HTTPRedirection then
       location = URI(response['location'])
@@ -83,6 +83,7 @@ class CheckSSLHSTSStatus < Sensu::Plugin::Check::CLI
     if response.nil?
       return warning 'Bad response recieved from API'
     end
+
     body = JSON.parse(response.body)
     unless STATUSES.include? body['status']
       warning 'Invalid status returned ' + body['status']

--- a/bin/check-ssl-qualys.rb
+++ b/bin/check-ssl-qualys.rb
@@ -1,6 +1,4 @@
 #!/usr/bin/env ruby
-# encoding: UTF-8
-
 #  check-ssl-qualys.rb
 #
 # DESCRIPTION:
@@ -138,7 +136,8 @@ class CheckSSLQualys < Sensu::Plugin::Check::CLI
                ssl_check(true)
              end
       return json if json['status'] == 'READY'
-      if json['endpoints'] && json['endpoints'].is_a?(Array)
+
+      if json['endpoints']&.is_a?(Array)
         p "endpoints: #{json['endpoints']}" if config[:debug]
         # The api response sometimes has low eta (which seems unrealistic) from
         # my tests that can be 0 or low numbers which would imply it is done...

--- a/bin/check-ssl-root-issuer.rb
+++ b/bin/check-ssl-root-issuer.rb
@@ -62,12 +62,12 @@ class CheckSSLRootIssuer < Sensu::Plugin::Check::CLI
          short: '-f',
          long: '--format FORMAT_VAL',
          default: 'RFC2253',
-         in: %w('RFC2253', 'ONELINE', 'COMPAT'),
+         in: %w[RFC2253 ONELINE COMPAT],
          required: false
 
   def cert_name_format
     # Note: because format argument is pre-validated by mixin 'in' logic eval is safe to use
-    eval "OpenSSL::X509::Name::#{config[:format]}" # rubocop:disable Lint/Eval
+    eval "OpenSSL::X509::Name::#{config[:format]}" # rubocop:disable Security/Eval, Style/EvalWithLocation
   end
 
   def validate_issuer(cert)
@@ -91,7 +91,7 @@ class CheckSSLRootIssuer < Sensu::Plugin::Check::CLI
     http.verify_mode = OpenSSL::SSL::VERIFY_PEER
 
     http.verify_callback = lambda { |verify_ok, store_context|
-      root_cert = store_context.current_cert unless root_cert
+      root_cert ||= store_context.current_cert
       unless verify_ok
         @failed_cert = store_context.current_cert
         @failed_cert_reason = [store_context.error, store_context.error_string] if store_context.error != 0

--- a/sensu-plugins-ssl.gemspec
+++ b/sensu-plugins-ssl.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'date'
@@ -15,14 +15,16 @@ Gem::Specification.new do |s|
                               verification, cert and crl expiry, and Qualys SSL Labs reporting'
   s.email                  = '<sensu-users@googlegroups.com>'
   s.executables            = Dir.glob('bin/**/*.rb').map { |file| File.basename(file) }
-  s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
+  s.files                  = Dir.glob('{bin,lib}/**/*') + %w[LICENSE README.md CHANGELOG.md]
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-ssl'
   s.license                = 'MIT'
-  s.metadata               = { 'maintainer'         => 'sensu-plugin',
-                               'development_status' => 'active',
-                               'production_status'  => 'unstable - testing recommended',
-                               'release_draft'      => 'false',
-                               'release_prerelease' => 'false' }
+  s.metadata               = {
+    'maintainer' => 'sensu-plugin',
+    'development_status' => 'active',
+    'production_status' => 'unstable - testing recommended',
+    'release_draft' => 'false',
+    'release_prerelease' => 'false'
+  }
   s.name                   = 'sensu-plugins-ssl'
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
@@ -43,6 +45,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
   s.add_development_dependency 'rspec',                     '~> 3.1'
   s.add_development_dependency 'rubocop',                   '~> 0.86.0'
-  s.add_development_dependency 'yard',                      '~> 0.8'
   s.add_development_dependency 'timecop',                   '~> 0.8.0'
+  s.add_development_dependency 'yard',                      '~> 0.8'
 end

--- a/sensu-plugins-ssl.gemspec
+++ b/sensu-plugins-ssl.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 2.5.8'
+  s.required_ruby_version  = '>= 2.7.1'
 
   s.summary                = 'Sensu plugins for SSL'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})

--- a/sensu-plugins-ssl.gemspec
+++ b/sensu-plugins-ssl.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake',                      '~> 12.3'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
   s.add_development_dependency 'rspec',                     '~> 3.1'
-  s.add_development_dependency 'rubocop',                   '~> 0.40.0'
+  s.add_development_dependency 'rubocop',                   '~> 0.86.0'
   s.add_development_dependency 'yard',                      '~> 0.8'
   s.add_development_dependency 'timecop',                   '~> 0.8.0'
 end

--- a/sensu-plugins-ssl.gemspec
+++ b/sensu-plugins-ssl.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 2.4.0'
+  s.required_ruby_version  = '>= 2.5.8'
 
   s.summary                = 'Sensu plugins for SSL'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
## Pull Request Checklist
Fixes #31.

#### General
- [x] Changelog has been update in the [Unreleased] section
- [x] Existing tests pass
- [x] RuboCop

#### Purpose
Support for StartTLS (`-starttls PROTOCOL`). See man page from [OpenSSL](https://www.openssl.org/docs/man1.1.1/man1/openssl-s_client.html) under `-starttls protocol`.

#### Known Compatibility Issues
none

Edit: Updated Rubocop and Ruby 
Rubocop 0.40 -> 0.86.0
Ruby 2.4 (EOL) -> 2.7

Ran Rubocop autofix and updated the new cops.