### PR TITLE
Rubocop update to 1.9.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,3 @@
-
 Metrics/MethodLength:
   Max: 200
 
@@ -143,4 +142,83 @@ Style/SlicingWithRange:
 Style/StringConcatenation:
   Enabled: false
 
+Layout/SpaceBeforeBrackets:
+  Enabled: true
 
+Lint/AmbiguousAssignment:
+  Enabled: true
+
+Lint/DeprecatedConstants:
+  Enabled: true
+
+Lint/DuplicateBranch:
+  Enabled: true
+
+Lint/DuplicateRegexpCharacterClassElement:
+  Enabled: true
+
+Lint/EmptyBlock:
+  Enabled: true
+
+Lint/EmptyClass:
+  Enabled: true
+
+Lint/LambdaWithoutLiteralBlock:
+  Enabled: true
+
+Lint/NoReturnInBeginEndBlocks:
+  Enabled: true
+
+Lint/NumberedParameterAssignment:
+  Enabled: true
+
+Lint/OrAssignmentToConstant:
+  Enabled: true
+
+Lint/RedundantDirGlobSort:
+  Enabled: true
+
+Lint/SymbolConversion:
+  Enabled: true
+
+Lint/ToEnumArguments:
+  Enabled: true
+
+Lint/TripleQuotes:
+  Enabled: true
+
+Lint/UnexpectedBlockArity:
+  Enabled: true
+
+Lint/UnmodifiedReduceAccumulator:
+  Enabled: true
+
+Style/ArgumentsForwarding:
+  Enabled: true
+
+Style/CollectionCompact:
+  Enabled: true
+
+Style/DocumentDynamicEvalDefinition:
+  Enabled: true
+
+Style/EndlessMethod:
+  Enabled: true
+
+Style/HashExcept:
+  Enabled: true
+
+Style/IfWithBooleanLiteralBranches:
+  Enabled: true
+
+Style/NegatedIfElseCondition:
+  Enabled: true
+
+Style/NilLambda:
+  Enabled: true
+
+Style/RedundantArgument:
+  Enabled: true
+
+Style/SwapValues:
+  Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md).
 
 ## [Unreleased]
+- Ugraded Rubocop to 1.9.1 and fix failing tests (@elfranne)
 
 ### Changed
 - Removed centos build from .bonsai.yml

--- a/Rakefile
+++ b/Rakefile
@@ -13,8 +13,7 @@ ENV['TZ'] = 'CET'
 args = %i[spec make_bin_executable yard rubocop check_binstubs]
 
 YARD::Rake::YardocTask.new do |t|
-  OTHER_PATHS = %w[].freeze
-  t.files = ['lib/**/*.rb', 'bin/**/*.rb', OTHER_PATHS]
+  t.files = ['lib/**/*.rb', 'bin/**/*.rb']
   t.options = %w[--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md]
 end
 

--- a/bin/check-ssl-cert.rb
+++ b/bin/check-ssl-cert.rb
@@ -97,10 +97,10 @@ class CheckSSLCert < Sensu::Plugin::Check::CLI
     elsif config[:pem]
       unknown 'No such cert' unless File.exist? config[:pem]
     elsif config[:pkcs12]
-      if !config[:pass]
-        unknown 'No pass phrase specified for PKCS#12 certificate'
-      else
+      if config[:pass]
         unknown 'No such cert' unless File.exist? config[:pkcs12]
+      else
+        unknown 'No pass phrase specified for PKCS#12 certificate'
       end
     end
     config[:servername] = config[:host] unless config[:servername]

--- a/bin/check-ssl-root-issuer.rb
+++ b/bin/check-ssl-root-issuer.rb
@@ -68,7 +68,7 @@ class CheckSSLRootIssuer < Sensu::Plugin::Check::CLI
          required: false
 
   def cert_name_format
-    # Note: because format argument is pre-validated by mixin 'in' logic eval is safe to use
+    # NOTE: because format argument is pre-validated by mixin 'in' logic eval is safe to use
     eval "OpenSSL::X509::Name::#{config[:format]}" # rubocop:disable Security/Eval, Style/EvalWithLocation
   end
 
@@ -100,7 +100,7 @@ class CheckSSLRootIssuer < Sensu::Plugin::Check::CLI
       end
       verify_ok
     }
-    http.start {}
+    http.start
     root_cert
   end
 

--- a/sensu-plugins-ssl.gemspec
+++ b/sensu-plugins-ssl.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake',                      '~> 13.0'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
   s.add_development_dependency 'rspec',                     '~> 3.1'
-  s.add_development_dependency 'rubocop',                   '~> 0.89.1'
+  s.add_development_dependency 'rubocop',                   '~> 1.9.1'
   s.add_development_dependency 'timecop',                   '~> 0.9.1'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end


### PR DESCRIPTION
## Pull Request Checklist

Ugraded Rubocop to 1.9.1 and fix failing tests 

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

About: `  OTHER_PATHS = %w[].freeze`
It can be used to add other path to libs but where is it used ? I have searched the whole Sensu Community Plugins but could not find it's being used.
