### PR TITLE
Check expiry in hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+### Added
+- `check-ssh-cert.rb` can now calculate expiry in hours, instead of days.
+
 ### Changed
 - Removed centos build from .bonsai.yml
 


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
No

#### General

- [X] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [X] RuboCop passes

- [X] Existing tests pass

#### Purpose
`check-ssh-cert.rb` can now calculate expiry in hours, instead of days. Useful for short-lived (<24h) ACME certs.

#### Known Compatibility Issues
None
